### PR TITLE
Restore compatibility with Alcotest.1.4.0

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -101,7 +101,7 @@ let check_bool msg = Alcotest.(check bool) msg
 let check_true msg = check_bool msg true
 let check_string = Alcotest.(check string)
 let check_int = Alcotest.(check int)
-let fail = Alcotest.fail
+let fail s = Alcotest.fail s
 
 let test_selector (type s) page f (module M : PageElement with type t = s) node prefix selector expected_count =
   let nodes = f selector page in


### PR DESCRIPTION
Alcotest 1.4.0 adds optional arguments to `Alcotest.fail`, making it necessary to eta-expand in order to use it with pipes.